### PR TITLE
Request fixed maximum number of comments from server

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -38,8 +38,11 @@ public class DataServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     
+    String queryString = request.getQueryString();
+    HashMap<String,String> fieldValues = getFieldValues(queryString);
+
     // Limit number of comments fetched from server to numOfComments
-    int numOfComments = 3;
+    int numOfComments = Integer.parseInt(fieldValues.get("quantity"));
     FetchOptions fetchOptions = FetchOptions.Builder.withLimit(numOfComments); 
     
     Query query = new Query("Comment");
@@ -89,5 +92,24 @@ public class DataServlet extends HttpServlet {
     Gson gson = new Gson();
     String json = gson.toJson(list);
     return json;
+  }
+
+  /**
+   * Converts queryString into HashMap of field and value pairs obtained 
+   * from the queryString
+   * @param queryString query string of which the field value pair are to be processed
+   * @return HashMap of field:value mappings
+   */
+  private HashMap<String, String> getFieldValues(String queryString) {
+    String[] fieldValueStr = queryString.split("&");
+    HashMap<String, String> fieldValues = new HashMap<String, String>();
+
+    for (String param : fieldValueStr) {
+      String[] fieldAndValue = queryString.split("=");
+      String field = fieldAndValue[0];
+      String value = fieldAndValue[1];
+      fieldValues.put(field, value);
+    }
+    return fieldValues;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -20,7 +20,6 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
-import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -17,6 +17,7 @@ package com.google.sps.servlets;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
@@ -36,13 +37,18 @@ public class DataServlet extends HttpServlet {
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    
+    // Limit number of comments fetched from server to numOfComments
+    int numOfComments = 3;
+    FetchOptions fetchOptions = FetchOptions.Builder.withLimit(numOfComments); 
+    
     Query query = new Query("Comment");
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
 
     List<HashMap<String, String>> commentList = new ArrayList<HashMap<String, String>>();
 
-    for (Entity entity : results.asIterable()) {
+    for (Entity entity : results.asIterable(fetchOptions)) {
       // Each comment and the associated data (author, etc.) will be a HashMap, which converts to JSON object
       HashMap<String, String> comment = new HashMap<String, String>();
       String commentText = (String) entity.getProperty("commentText");

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -105,7 +105,7 @@ public class DataServlet extends HttpServlet {
     HashMap<String, String> fieldValues = new HashMap<String, String>();
 
     for (String param : fieldValueStr) {
-      String[] fieldAndValue = queryString.split("=");
+      String[] fieldAndValue = param.split("=");
       String field = fieldAndValue[0];
       String value = fieldAndValue[1];
       fieldValues.put(field, value);

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -56,15 +56,20 @@
           </form>
         </div>
       </div>
-      <div id="comments-to-show-selector">
-        <form> <!-- not sure if the form wrapper is necessary -->
-          <select onchange="fetchComments(this.value)" name="comments-to-show">
-            <option value="5">5</option>
-            <option value="10">10</option>
-            <option value="15">15</option>
-            <option value="20">20</option>
-          </select>
-        </form>
+      <div id="comment-display-toggles" class="flex-container">
+        <div class="display-toggle-heading">
+          <p class="body-text">View:</p>
+        </div>
+        <div class="display-toggle-form">
+          <form class="body-text" id="comments-to-show-selector">
+            <select onchange="fetchComments(this.value)" name="comments-to-show">
+              <option value="5">5</option>
+              <option value="10">10</option>
+              <option value="15">15</option>
+              <option value="20">20</option>
+            </select>
+          </form>
+        </div>
       </div>
       <div id="comment-list" class="flex-container">
         <!-- Submitted comments will be generated here by fetchComments() on page load. -->

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -7,7 +7,7 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <script src="script.js"></script>
   </head>
-  <body onload="fetchComments()">
+  <body onload="fetchComments(5)"> <!-- Default to 5 comments on load -->
     <div id="content" class="flex-container">
       <div class="header-div">
         <h1 class="heading-text">My Portfolio</h1>
@@ -55,6 +55,16 @@
             </div>
           </form>
         </div>
+      </div>
+      <div id="comments-to-show-selector">
+        <form> <!-- not sure if the form wrapper is necessary -->
+          <select onchange="fetchComments(this.value)" name="comments-to-show">
+            <option value="5">5</option>
+            <option value="10">10</option>
+            <option value="15">15</option>
+            <option value="20">20</option>
+          </select>
+        </form>
       </div>
       <div id="comment-list" class="flex-container">
         <!-- Submitted comments will be generated here by fetchComments() on page load. -->

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -60,8 +60,13 @@ function toggleBlogPost(buttonId) {
  * @return none
  */
 function fetchComments(quantity) {
-  var queryString = '/data' + '?quantity=' + String(quantity);
-  fetch(queryString).then(response => response.json()).then((commentData) => {
+  
+  const endpoint = '/data?';
+  var queryString = new URLSearchParams();
+  queryString.append('quantity', String(quantity));
+  const url = endpoint + queryString.toString();
+
+  fetch(url).then(response => response.json()).then((commentData) => {
     // clear any comment data currently displayed
     document.getElementById('comment-list').innerHTML = ""
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -56,12 +56,15 @@ function toggleBlogPost(buttonId) {
 /**
  * Fetches comments JSON from server at /data URL and adds the message to 
  * the div with id "comment-list".
+ * @param quantity The number of comments to fetch from the server
  * @return none
  */
-function fetchComments() {
-  let quantity = 3;
+function fetchComments(quantity) {
   var queryString = '/data' + '?quantity=' + String(quantity);
   fetch(queryString).then(response => response.json()).then((commentData) => {
+    // clear any comment data currently displayed
+    document.getElementById('comment-list').innerHTML = ""
+
     let commentContent = "";
     for (let i = 0; i < commentData.length; i++) {
       let commentText = commentData[i].commentText; // The actual comment

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -59,7 +59,9 @@ function toggleBlogPost(buttonId) {
  * @return none
  */
 function fetchComments() {
-  fetch('/data').then(response => response.json()).then((commentData) => {
+  let quantity = 3;
+  var queryString = '/data' + '?quantity=' + String(quantity);
+  fetch(queryString).then(response => response.json()).then((commentData) => {
     let commentContent = "";
     for (let i = 0; i < commentData.length; i++) {
       let commentText = commentData[i].commentText; // The actual comment

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -148,9 +148,9 @@ input {
 /* Comments display */
 
 .comment { 
-    /* This class of items is rendered by fetchComments() in script.js, 
-    where there are existing comments */ 
-    width: 100%;
+  /* This class of items is rendered by fetchComments() in script.js, 
+  where there are existing comments */ 
+  width: 100%;
 }
 
 #comment-display-toggles {

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -145,8 +145,35 @@ input {
   width: 30%;
 }
 
+/* Comments display */
+
 .comment { 
     /* This class of items is rendered by fetchComments() in script.js, 
     where there are existing comments */ 
     width: 100%;
+}
+
+#comment-display-toggles {
+  /* align all display toggles on the right of page */
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.display-toggle-heading {
+  /* add some space between heading and selector */
+  padding-right: 8px;
+}
+
+.display-toggle-form {
+  /* center all display toggle forms vertically in the div */
+  display: flex;
+  flex-direction: column; 
+  justify-content: center; 
+}
+
+.display-toggle-form select {
+  /* style the selector */
+  font-family: inherit; /* inherit from body-text */
+  font-size: inherit;
+  padding: 2px;
 }


### PR DESCRIPTION
Add front-end and back-end support to allow users to choose how many comments to display.

Allow user to choose how many comments to display on `index.html` via a `select` element. The value of the `select` element will be passed to `fetchComments` which will fetch that number of comments from the server.