### PR TITLE
Associate user email with comments made by logged in user

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -70,9 +70,11 @@ public class DataServlet extends HttpServlet {
       String commentText = (String) entity.getProperty("commentText");
       String commentAuthor = (String) entity.getProperty("commentAuthor");
       String imageUrl = (String) entity.getProperty("attachedImage");
+      String email = (String) entity.getProperty("authorEmail");
       comment.put("commentText", commentText);
       comment.put("commentAuthor", commentAuthor);
       comment.put("attachedImage", imageUrl); 
+      comment.put("authorEmail", email);
       commentList.add(comment);
     }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -28,6 +28,8 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.images.ImagesService;
 import com.google.appengine.api.images.ImagesServiceFactory;
 import com.google.appengine.api.images.ServingUrlOptions;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -92,10 +94,16 @@ public class DataServlet extends HttpServlet {
     String commentText = request.getParameter("comment");
     String commentAuthor = request.getParameter("author-name");
 
+    // Get the user email and store with their comment
+    // NOTE do not need to check login status, because only logged in users can access comment form
+    UserService userService = UserServiceFactory.getUserService();
+    String email = userService.getCurrentUser().getEmail();
+
     // Store in DataStore
     Entity commentEntity = new Entity("Comment");
     commentEntity.setProperty("commentText", commentText);
     commentEntity.setProperty("commentAuthor", commentAuthor);
+    commentEntity.setProperty("authorEmail", email);
     if (imageUrl != null) {
       commentEntity.setProperty("attachedImage", imageUrl);
       commentEntity.setProperty("blobKey", blobKey.getKeyString()); // used to delete image when comment is deleted

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -82,11 +82,15 @@ function fetchComments(quantity=5) {
         
         // Comment author name: "'Anonymous' if there was not a name submitted."
         let commentAuthor = commentData[i].commentAuthor === "" ? "Anonymous" : commentData[i].commentAuthor; 
-        
+
+        // 'No email provided' if comment had been submitted before implementation of authentication
+        let authorEmail = commentData[i].authorEmail === "" ? "No email provided" : commentData[i].authorEmail;
+
         // Display image as well, if there is an image
         let imageUrl = commentData[i].attachedImage;
-        commentContent += '<div class="comment"><div class="flex-item"><p class="body-text"><b>' + commentAuthor + '</b></p>' 
-              + '<p class="body-text">' + commentText + '</p></div>'; // outer <div> not closed yet
+        commentContent += '<div class="comment"><div class="flex-item"><p class="body-text"><b>' + commentAuthor + '</b></p>'
+            + '<p class="footnote-text"> ' + authorEmail + '</p>'
+            + '<p class="body-text">' + commentText + '</p></div>'; // outer <div> not closed yet
 
         if (imageUrl == null) {
           commentContent += '</div>'; // close outer div


### PR DESCRIPTION
Store user email in the Comment datastore entity of the comment submitted by a logged in user.
Add this user email to the response JSON from the DataServlet, and display the emails alongside their associated comments in the front-end.