### PR TITLE
Display user nickname instead of name submitted with form or their email address

### DIFF
--- a/portfolio/src/main/java/com/google/sps/data/Nickname.java
+++ b/portfolio/src/main/java/com/google/sps/data/Nickname.java
@@ -1,0 +1,43 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.data;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+
+/** Class of helper functions to faciliate user nicknames. */
+public class Nickname {
+
+  /** Returns the nickname of the user with id, or null if the user has not 
+   * set a nickname. 
+   * @param id user id of the user.
+   */
+  public static String getUserNickname(String id) {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Query query = 
+        new Query("UserInfo")
+            .setFilter(new Query.FilterPredicate("id", Query.FilterOperator.EQUAL, id));
+    PreparedQuery results = datastore.prepare(query);
+    Entity entity = results.asSingleEntity();
+    if (entity == null) {
+      return null;
+    }
+    String nickname = (String) entity.getProperty("nickname");
+    return nickname;
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -56,23 +56,23 @@ public class DataServlet extends HttpServlet {
     HashMap<String,String> fieldValues = getFieldValues(queryString);
 
     // Limit number of comments fetched from server to numOfComments
-    int numOfComments = Integer.parseInt(fieldValues.get("quantity"));
+    int numOfComments = Integer.parseInt((String) fieldValues.get("quantity"));
     FetchOptions fetchOptions = FetchOptions.Builder.withLimit(numOfComments); 
     
     Query query = new Query("Comment");
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);
 
-    List<HashMap<String, String>> commentList = new ArrayList<HashMap<String, String>>();
+    List<HashMap<String, Object>> commentList = new ArrayList<HashMap<String, Object>>();
 
     for (Entity entity : results.asIterable(fetchOptions)) {
       // Each comment and the associated data (author, etc.) will be a HashMap, which converts to JSON object
-      HashMap<String, String> comment = new HashMap<String, String>();
+      HashMap<String, Object> comment = new HashMap<String, Object>();
       String commentText = (String) entity.getProperty("commentText");
       String commentAuthor = (String) entity.getProperty("commentAuthor");
       String imageUrl = (String) entity.getProperty("attachedImage");
-      String showEmail = (String) entity.getProperty("showEmail");
-      if (Boolean.parseBoolean(showEmail) == true) {
+      Boolean showEmail = (Boolean) entity.getProperty("showEmail");
+      if (showEmail) {
         String email = (String) entity.getProperty("authorEmail");
         comment.put("authorEmail", email);
       }
@@ -99,7 +99,7 @@ public class DataServlet extends HttpServlet {
     }
     // Get input from the form
     String commentText = request.getParameter("comment");
-    String showEmail = request.getParameter("show-email");
+    Boolean showEmail = Boolean.parseBoolean(request.getParameter("show-email"));
 
     // Get the user email and store with their comment
     // NOTE do not need to check login status, because only logged in users can access comment form
@@ -132,7 +132,7 @@ public class DataServlet extends HttpServlet {
    * @param list the List of HashMap<String, String> to be converted to JSON
    * @return a JSON String with the ArrayList contents.
    */
-  private String convertToJson(List<HashMap<String, String>> list) {
+  private String convertToJson(List<HashMap<String, Object>> list) {
     Gson gson = new Gson();
     String json = gson.toJson(list);
     return json;

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -70,10 +70,12 @@ public class DataServlet extends HttpServlet {
       String commentText = (String) entity.getProperty("commentText");
       String commentAuthor = (String) entity.getProperty("commentAuthor");
       String imageUrl = (String) entity.getProperty("attachedImage");
+      String showEmail = (String) entity.getProperty("showEmail");
       String email = (String) entity.getProperty("authorEmail");
       comment.put("commentText", commentText);
       comment.put("commentAuthor", commentAuthor);
       comment.put("attachedImage", imageUrl); 
+      comment.put("showEmail", showEmail);
       comment.put("authorEmail", email);
       commentList.add(comment);
     }
@@ -94,6 +96,7 @@ public class DataServlet extends HttpServlet {
     }
     // Get input from the form
     String commentText = request.getParameter("comment");
+    String showEmail = request.getParameter("show-email");
 
     // Get the user email and store with their comment
     // NOTE do not need to check login status, because only logged in users can access comment form
@@ -109,6 +112,7 @@ public class DataServlet extends HttpServlet {
     commentEntity.setProperty("commentText", commentText);
     commentEntity.setProperty("commentAuthor", nickname);
     commentEntity.setProperty("authorEmail", email);
+    commentEntity.setProperty("showEmail", showEmail);
     if (imageUrl != null) {
       commentEntity.setProperty("attachedImage", imageUrl);
       commentEntity.setProperty("blobKey", blobKey.getKeyString()); // used to delete image when comment is deleted

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -72,12 +72,14 @@ public class DataServlet extends HttpServlet {
       String commentAuthor = (String) entity.getProperty("commentAuthor");
       String imageUrl = (String) entity.getProperty("attachedImage");
       String showEmail = (String) entity.getProperty("showEmail");
-      String email = (String) entity.getProperty("authorEmail");
+      if (Boolean.parseBoolean(showEmail) == true) {
+        String email = (String) entity.getProperty("authorEmail");
+        comment.put("authorEmail", email);
+      }
       comment.put("commentText", commentText);
       comment.put("commentAuthor", commentAuthor);
       comment.put("attachedImage", imageUrl); 
       comment.put("showEmail", showEmail);
-      comment.put("authorEmail", email);
       commentList.add(comment);
     }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -31,6 +31,7 @@ import com.google.appengine.api.images.ServingUrlOptions;
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
 import com.google.gson.Gson;
+import com.google.sps.data.Nickname;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -105,7 +106,7 @@ public class DataServlet extends HttpServlet {
 
     // Get user nickname and store with their comment
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    String nickname = getUserNickname(userService.getCurrentUser().getUserId());
+    String nickname = Nickname.getUserNickname(userService.getCurrentUser().getUserId());
 
     // Store in DataStore
     Entity commentEntity = new Entity("Comment");
@@ -202,23 +203,5 @@ public class DataServlet extends HttpServlet {
     } catch (MalformedURLException e) {
       return imagesService.getServingUrl(options);
     }
-  }
-
-  /** Returns the nickname of the user with id, or null if the user has not 
-   * set a nickname. 
-   * @param id user id of the user.
-   */
-  private String getUserNickname(String id) {
-    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    Query query = 
-        new Query("UserInfo")
-            .setFilter(new Query.FilterPredicate("id", Query.FilterOperator.EQUAL, id));
-    PreparedQuery results = datastore.prepare(query);
-    Entity entity = results.asSingleEntity();
-    if (entity == null) {
-      return null;
-    }
-    String nickname = (String) entity.getProperty("nickname");
-    return nickname;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
@@ -19,10 +19,9 @@ import java.io.IOException;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
-import com.google.appengine.api.datastore.PreparedQuery;
-import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.sps.data.Nickname;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -45,7 +44,7 @@ public class NicknameServlet extends HttpServlet {
       return;
     }
 
-    String nickname = getUserNickname(userService.getCurrentUser().getUserId());
+    String nickname = Nickname.getUserNickname(userService.getCurrentUser().getUserId());
     if (nickname == null) {
       response.sendRedirect("/createUserProfile.html");
       return;
@@ -76,23 +75,5 @@ public class NicknameServlet extends HttpServlet {
     datastore.put(entity);
 
     response.sendRedirect("/index.html");
-  }
-
-  /** Returns the nickname of the user with id, or null if the user has not 
-   * set a nickname. 
-   * @param id user id of the user.
-   */
-  private String getUserNickname(String id) {
-    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    Query query = 
-        new Query("UserInfo")
-            .setFilter(new Query.FilterPredicate("id", Query.FilterOperator.EQUAL, id));
-    PreparedQuery results = datastore.prepare(query);
-    Entity entity = results.asSingleEntity();
-    if (entity == null) {
-      return null;
-    }
-    String nickname = (String) entity.getProperty("nickname");
-    return nickname;
   }
 }

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -48,10 +48,6 @@
               <input class="long-input" type="text" name="comment" required>
             </div>
             <div>
-              <label for="author-name">Name</label><br/>
-              <input class="short-input" type="text" name="author-name">
-            </div>
-            <div>
               <label for="image-upload">Upload an image</label><br/>
               <input class="short-input" type="file" name="image-upload">
             </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -43,15 +43,15 @@
         </div>
         <div class="comment-form-body">
           <form id="comment-form" class="body-text" method="POST" enctype="multipart/form-data">
-            <div>
+            <div class="form-field">
               <label for="comment">Comment<span id="req-field-indicator">*</span></label><br/>
               <input class="long-input" type="text" name="comment" required>
             </div>
-            <div>
+            <div class="form-field">
               <label for="image-upload">Upload an image</label><br/>
               <input class="short-input" type="file" name="image-upload">
             </div>
-            <div>
+            <div class="form-field">
               <input type="checkbox" id="show-email" name="show-email" value="true">
               <label for="show-email">Show my email in my comment</label><br>
             </div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -52,6 +52,10 @@
               <input class="short-input" type="file" name="image-upload">
             </div>
             <div>
+              <input type="checkbox" id="show-email" name="show-email" value="true">
+              <label for="show-email">Show my email in my comment</label><br>
+            </div>
+            <div>
               <button type="submit">Submit</button>
             </div>
           </form>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -84,7 +84,7 @@ function fetchComments(quantity=5) {
         
         let authorEmailContent = "";
         // Show email if the user said so
-        if (commentData[i].showEmail == 'true') {
+        if (commentData[i].showEmail == true) {
           // 'No email provided' if comment had been submitted before implementation of authentication
           let authorEmail = commentData[i].authorEmail === "" ? "No email provided" : commentData[i].authorEmail;
           authorEmailContent = '<p class="footnote-text"> ' + authorEmail + '</p>';

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -82,14 +82,19 @@ function fetchComments(quantity=5) {
         
         // Comment author name: "'Anonymous' if there was not a name submitted."
         let commentAuthor = commentData[i].commentAuthor === "" ? "Anonymous" : commentData[i].commentAuthor; 
-
-        // 'No email provided' if comment had been submitted before implementation of authentication
-        let authorEmail = commentData[i].authorEmail === "" ? "No email provided" : commentData[i].authorEmail;
+        
+        let authorEmailContent = "";
+        // Show email if the user said so
+        if (commentData[i].showEmail != null) {
+          // 'No email provided' if comment had been submitted before implementation of authentication
+          let authorEmail = commentData[i].authorEmail === "" ? "No email provided" : commentData[i].authorEmail;
+          authorEmailContent = '<p class="footnote-text"> ' + authorEmail + '</p>';
+        }
 
         // Display image as well, if there is an image
         let imageUrl = commentData[i].attachedImage;
         commentContent += '<div class="comment"><div class="flex-item"><p class="body-text"><b>' + commentAuthor + '</b></p>'
-            + '<p class="footnote-text"> ' + authorEmail + '</p>'
+            + authorEmailContent
             + '<p class="body-text">' + commentText + '</p></div>'; // outer <div> not closed yet
 
         if (imageUrl == null) {

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -69,8 +69,7 @@ function fetchComments(quantity=5) {
   const url = endpoint + queryString.toString();
 
   fetch(url).then(response => response.json()).then((commentData) => {
-    
-    let commentContent = ""
+    let commentContent = "";
     
     if (commentData.length === 0 ) { // if there are no existing comments
       // disable the delete comments button & display "No Comments"
@@ -85,7 +84,7 @@ function fetchComments(quantity=5) {
         
         let authorEmailContent = "";
         // Show email if the user said so
-        if (commentData[i].showEmail != null) {
+        if (commentData[i].showEmail == 'true') {
           // 'No email provided' if comment had been submitted before implementation of authentication
           let authorEmail = commentData[i].authorEmail === "" ? "No email provided" : commentData[i].authorEmail;
           authorEmailContent = '<p class="footnote-text"> ' + authorEmail + '</p>';

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -143,6 +143,10 @@ button {
   padding-left: 8px;
 }
 
+.form-field {
+  margin-top: 10px;
+}
+
 input {
   font-family: 'Open Sans', sans-serif;
   font-size: 15px;


### PR DESCRIPTION
Display the user nickname they set when logging in for the first time as the author name of the associated comment. 
Remove the "Name" form field, as this is now redundant.
Provide the user with the option of showing their email with their comment (a checkbox field on the comment form).