### PR TITLE
Remove ImageService dependency and serve image blobs direct from BlobStore

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/ImageBlobsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ImageBlobsServlet.java
@@ -1,0 +1,39 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.appengine.api.blobstore.BlobKey;
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Serves image blobs directly from the blobstore */
+@WebServlet("/serve-images")
+public class ImageBlobsServlet extends HttpServlet {
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String queryString = request.getQueryString();
+    if (queryString == null) {
+      return;
+    }
+    BlobKey blobKey = new BlobKey(request.getParameter("blob-key"));
+    BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+    blobstoreService.serve(blobKey, response);
+  }
+}

--- a/portfolio/src/main/java/com/google/sps/servlets/ImageBlobsServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/ImageBlobsServlet.java
@@ -32,7 +32,12 @@ public class ImageBlobsServlet extends HttpServlet {
     if (queryString == null) {
       return;
     }
-    BlobKey blobKey = new BlobKey(request.getParameter("blob-key"));
+    String blobKeyString = request.getParameter("blob-key");
+    // If there is no blob-key
+    if (blobKeyString == null) {
+      return;
+    }
+    BlobKey blobKey = new BlobKey(blobKeyString);
     BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
     blobstoreService.serve(blobKey, response);
   }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -94,9 +94,7 @@ function fetchComments(quantity=5) {
 
         // Display image as well, if there is an image
         let blobKey = commentData[i].blobKey;
-        fetchCommentImage(blobKey).then((url) => {
-          let imageUrl = url;
-
+        fetchCommentImage(blobKey).then((imageUrl) => {
           commentContent += '<div class="comment"><div class="flex-item"><p class="body-text"><b>' + commentAuthor + '</b></p>'
               + authorEmailContent
               + '<p class="body-text">' + commentText + '</p></div>'; // outer <div> not closed yet

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -70,7 +70,7 @@ function fetchComments(quantity=5) {
 
   fetch(url).then(response => response.json()).then((commentData) => {
     let commentContent = "";
-    
+
     if (commentData.length === 0 ) { // if there are no existing comments
       // disable the delete comments button & display "No Comments"
       document.getElementById('delete-comments-button').setAttribute('disabled','true');
@@ -99,8 +99,10 @@ function fetchComments(quantity=5) {
               + authorEmailContent
               + '<p class="body-text">' + commentText + '</p></div>'; // outer <div> not closed yet
 
-          if (imageUrl == null) {
+          if (imageUrl === null) { // No image
             commentContent += '</div>'; // close outer div
+          } else if (imageUrl === undefined) { // Error occured
+            commentContent += '<div class="body-text">Error fetching image</div></div>';
           } else {
             commentContent += '<div class="flex-item"><a href=' + imageUrl + ' target="_blank"><img class="comment-image" src=' 
                 + imageUrl + '></a></div></div>'; // add image
@@ -183,9 +185,16 @@ async function fetchCommentImage(blobKey) {
     return null;
   }
   const response = await fetch(`/serve-images?blob-key=${blobKey}`);
-  // parse the body of the response as a Blob.
-  const blob = await response.blob();
-  // create a URL for accessing the Blob.
-  const imageURL = window.URL.createObjectURL(blob);
-  return imageURL; 
+  // check that response was successful
+  if (response.ok) {
+    // parse the body of the response as a Blob.
+    const blob = await response.blob();
+    // create a URL for accessing the Blob.
+    const imageURL = window.URL.createObjectURL(blob);
+    return imageURL; 
+  }
+  else {
+    console.log("Error fetching image: " + response.status + " " + response.statusText);
+    return undefined;
+  }
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -181,8 +181,8 @@ input {
 }
 
 .comment-image {
-  width: 80%;
   margin-bottom: 4px;
+  width: 60%;
 }
 
 #comment-display-toggles {


### PR DESCRIPTION
Previously, ImageService was used to generate a URL for the image in Blobstore, and this URL was stored in DataStore and also used to display the image. However, it is a known issue that ImageService does not work after the website has been deployed (see [[Step Internship] Known Issues and FAQs](https://docs.google.com/document/d/1_Hyte0_3IJ9nPglQ4G116BXjuIK3dXxI5tQXy9rPpp0/)). 
Hence, the ImageService dependency is removed here, and instead the image blobs are served to the client code directly from Blobstore.