### PR TITLE
Verify that user uploaded an image before storing BlobKey

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -48,6 +48,8 @@ public class DataServlet extends HttpServlet {
   // Supported upload file types of the comment form
   private final HashSet<String> FILETYPES = new HashSet<String>(
       Arrays.asList("image/jpeg", "image/jpg", "image/png"));
+  // upload file size limit
+  private final double MAX_FILESIZE = 5 * Math.pow(10, 6);
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -174,7 +176,7 @@ public class DataServlet extends HttpServlet {
     final BlobInfo blobInfo = new BlobInfoFactory().loadBlobInfo(blobKey);
     long size = blobInfo.getSize();
     String type = blobInfo.getContentType();
-    if (size > 0 && FILETYPES.contains(type)) {
+    if (size > 0 && size <= MAX_FILESIZE && FILETYPES.contains(type)) {
       return blobKey;
     } else {
       blobstoreService.delete(blobKey);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -14,6 +14,8 @@
 
 package com.google.sps.servlets;
 
+import com.google.appengine.api.blobstore.BlobInfo;
+import com.google.appengine.api.blobstore.BlobInfoFactory;
 import com.google.appengine.api.blobstore.BlobKey;
 import com.google.appengine.api.blobstore.BlobstoreService;
 import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
@@ -29,7 +31,9 @@ import com.google.gson.Gson;
 import com.google.sps.data.Nickname;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import javax.servlet.annotation.WebServlet;
@@ -160,8 +164,21 @@ public class DataServlet extends HttpServlet {
       return null;
     }
 
-    // Our form only contains a single file input, so get the first index and return
+    // Our form only contains a single file input, so get the first index
     BlobKey blobKey = blobKeys.get(0);
-    return blobKey;
+
+    // Check that the user actually uploaded an image
+    final BlobInfo blobInfo = new BlobInfoFactory().loadBlobInfo(blobKey);
+    long size = blobInfo.getSize();
+    String type = blobInfo.getContentType();
+    // supported upload file types
+    HashSet<String> filetypes = new HashSet<String>();
+    filetypes.addAll(Arrays.asList("image/jpeg", "image/jpg", "image/png"));
+    if (size > 0 && filetypes.contains(type)) {
+      return blobKey;
+    } else {
+      blobstoreService.delete(blobKey);
+      return null;
+    }
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -45,6 +45,9 @@ import javax.servlet.http.HttpServletResponse;
  * Linked to <form> element on index.html with id='comment-form' */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
+  // Supported upload file types of the comment form
+  private final HashSet<String> FILETYPES = new HashSet<String>(
+      Arrays.asList("image/jpeg", "image/jpg", "image/png"));
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -171,10 +174,7 @@ public class DataServlet extends HttpServlet {
     final BlobInfo blobInfo = new BlobInfoFactory().loadBlobInfo(blobKey);
     long size = blobInfo.getSize();
     String type = blobInfo.getContentType();
-    // supported upload file types
-    HashSet<String> filetypes = new HashSet<String>();
-    filetypes.addAll(Arrays.asList("image/jpeg", "image/jpg", "image/png"));
-    if (size > 0 && filetypes.contains(type)) {
+    if (size > 0 && FILETYPES.contains(type)) {
       return blobKey;
     } else {
       blobstoreService.delete(blobKey);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -48,7 +48,7 @@ public class DataServlet extends HttpServlet {
   // Supported upload file types of the comment form
   private final HashSet<String> FILETYPES = new HashSet<String>(
       Arrays.asList("image/jpeg", "image/jpg", "image/png"));
-  // upload file size limit
+  // upload file size limit (bytes)
   private final double MAX_FILESIZE = 5 * Math.pow(10, 6);
 
   @Override


### PR DESCRIPTION
Ensure that user is uploading only files of type .jpeg, .jpg or .png (typical image files). 
If the file uploaded is not one of these 3 types, delete the Blob of the uploaded file, and return none. Otherwise return the BlobKey of the stored image file.